### PR TITLE
Chore: Disable KubeProxyDown, KubeSchedulerDown alerts

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,8 @@ defaultRules:
   rules:
     # GKE doesn't deploy a kubeScheduler
     kubeScheduler: false
+    # GKE Kube Proxy is not referenced properly with this mixin alert
+    kubeProxy: false
   disabled:
     # If Prometheus is failing to send alerts to any Alertmanager we will not
     # see this alert. It is therefore redundant. Instead we will be notified


### PR DESCRIPTION
These default Prometheus Operator mixin alerts are misconfigured for the GKE environment, are misfiring, and need to be disabled.

GitLab Issues: 
* https://gitlab.greenpeace.org/gp/git/global-apps/cms/planet4/documentation-and-issues/-/issues/646
* https://gitlab.greenpeace.org/gp/git/global-apps/cms/planet4/documentation-and-issues/-/issues/645