### PR TITLE
fix: increase tsdb capacity to 100Gi in production.

### DIFF
--- a/env/dev/values.yaml
+++ b/env/dev/values.yaml
@@ -24,6 +24,14 @@ prometheus:
       gp_name: planet4-dev
       cluster: planet4-dev
       gp_location: gcp
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 40Gi
   thanosIngress:
     hosts:
       - dev.thanos.p4.greenpeace.org

--- a/env/prod/values.yaml
+++ b/env/prod/values.yaml
@@ -24,6 +24,14 @@ prometheus:
       gp_name: planet4-prod
       cluster: planet4-prod
       gp_location: gcp
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi
   thanosIngress:
     hosts:
       - prod.thanos.p4.greenpeace.org

--- a/values.yaml
+++ b/values.yaml
@@ -30,14 +30,6 @@ prometheus:
         static_configs:
           - targets:
               - "alertmanager-2.greenpeace.net"
-    storageSpec:
-      volumeClaimTemplate:
-        spec:
-          storageClassName: standard
-          accessModes: ["ReadWriteOnce"]
-          resources:
-            requests:
-              storage: 40Gi
     resources:
       requests:
         cpu: 2500m


### PR DESCRIPTION
Resolves `KubePersistentVolumeFillingUp` alert firing in Production cluster. The persistent volume hit 97% capacity used. Production was previously set to `60Gi`, this PR increases it to `100Gi` while retaining `40Gi` in development.